### PR TITLE
Add Wikidata and MusicBrainz example apps

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -98,6 +98,18 @@
       <div class="card-desc">Browse any user's repos with live API data. File tree and README on demand.</div>
       <div class="card-tags"><span class="tag tag-api">GitHub API</span> <span class="tag">boot options</span></div>
     </a>
+    <a class="card" href="wikidata/">
+      <div class="card-icon">📺</div>
+      <div class="card-title">TV Series Browser</div>
+      <div class="card-desc">300+ TV series from Wikidata SPARQL. Genre filters, search, detail modal with IMDb links.</div>
+      <div class="card-tags"><span class="tag tag-api">Wikidata SPARQL</span> <span class="tag tag-api">Wikipedia API</span> <span class="tag">search</span> <span class="tag">filter</span></div>
+    </a>
+    <a class="card" href="musicbrainz/">
+      <div class="card-icon">🎵</div>
+      <div class="card-title">MusicBrainz Browser</div>
+      <div class="card-desc">Albums across 10 genres from MusicBrainz API. Cover art, genre and type filters, search, detail modal.</div>
+      <div class="card-tags"><span class="tag tag-api">MusicBrainz API</span> <span class="tag tag-api">Cover Art Archive</span> <span class="tag">search</span> <span class="tag">filter</span></div>
+    </a>
   </div>
 
   <div class="section-title">Universal Browser</div>

--- a/examples/musicbrainz/index.html
+++ b/examples/musicbrainz/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MusicBrainz Browser</title>
+  <style>
+    * { margin: 0; box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; color: #111; }
+    #losos { max-width: 100% !important; }
+    #losos > div { max-width: 100% !important; width: 100% !important; }
+    button.pane-tab { color: #999 !important; font-weight: 500 !important; background: transparent !important; border: none; padding: 8px 16px; cursor: pointer; }
+    button.pane-tab[aria-selected="true"] { color: #e11d48 !important; font-weight: 600 !important; border-bottom: 2px solid #e11d48 !important; }
+    .boot-loading {
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      height: 80vh; color: #999; font-size: 16px; gap: 20px;
+    }
+    .boot-spinner {
+      width: 44px; height: 44px;
+      border: 3px solid #e5e5e5; border-top-color: #e11d48;
+      border-radius: 50%; animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .boot-status { font-size: 13px; color: #aaa; }
+  </style>
+</head>
+<body>
+
+<script id="data" type="application/ld+json"></script>
+<script type="module" data-pane src="panes/music-pane.js"></script>
+<script type="module" data-pane src="panes/source-pane.js"></script>
+
+<div id="losos">
+  <div class="boot-loading">
+    <div class="boot-spinner"></div>
+    <div>Loading music from MusicBrainz...</div>
+    <div class="boot-status" id="boot-status"></div>
+  </div>
+</div>
+
+<script>
+(function() {
+  var dataEl = document.getElementById('data')
+  var statusEl = document.getElementById('boot-status')
+  var MB_API = 'https://musicbrainz.org/ws/2'
+
+  var context = {
+    "schema": "http://schema.org/",
+    "dct": "http://purl.org/dc/terms/",
+    "mb": "https://musicbrainz.org/",
+    "title": "dct:title",
+    "releases": "schema:hasPart",
+    "name": "schema:name",
+    "artist": "schema:byArtist",
+    "image": "schema:image",
+    "genre": "schema:genre",
+    "releaseDate": "schema:datePublished",
+    "releaseType": "schema:additionalType",
+    "mbid": "schema:identifier",
+    "score": "schema:ratingValue",
+    "MusicCatalog": "schema:MusicPlaylist",
+    "MusicAlbum": "schema:MusicAlbum"
+  }
+
+  function status(msg) {
+    if (statusEl) statusEl.textContent = msg
+  }
+
+  function delay(ms) {
+    return new Promise(function(resolve) { setTimeout(resolve, ms) })
+  }
+
+  function mbFetch(path) {
+    return fetch(MB_API + path, {
+      headers: { 'Accept': 'application/json' }
+    }).then(function(r) {
+      if (!r.ok) throw new Error('MusicBrainz API error: ' + r.status)
+      return r.json()
+    })
+  }
+
+  function coverArtUrl(mbid) {
+    return 'https://coverartarchive.org/release-group/' + mbid + '/front-250'
+  }
+
+  function extractYear(dateStr) {
+    if (!dateStr) return null
+    var m = dateStr.match(/(\d{4})/)
+    return m ? parseInt(m[1]) : null
+  }
+
+  function searchByTag(tag, limit) {
+    var q = encodeURIComponent('tag:"' + tag + '"')
+    return mbFetch('/release-group?query=' + q + '&type=album&limit=' + limit + '&fmt=json')
+  }
+
+  var seedGenres = ['rock', 'pop', 'jazz', 'electronic', 'hip hop', 'classical', 'soul', 'metal', 'folk', 'blues']
+
+  status('Fetching albums from MusicBrainz...')
+
+  var seen = {}
+  var allReleases = []
+  var loaded = 0
+
+  function loadGenre(genre) {
+    status('Loading ' + genre + ' albums... (' + (loaded + 1) + '/' + seedGenres.length + ')')
+    return searchByTag(genre, 100).then(function(data) {
+      var groups = data['release-groups'] || []
+      groups.forEach(function(rg) {
+        if (seen[rg.id]) return
+        seen[rg.id] = true
+
+        var artists = (rg['artist-credit'] || []).map(function(ac) {
+          return ac.artist ? ac.artist.name : (ac.name || '')
+        }).filter(Boolean)
+
+        var tags = (rg.tags || [])
+          .sort(function(a, b) { return (b.count || 0) - (a.count || 0) })
+          .map(function(t) { return t.name })
+          .slice(0, 5)
+
+        allReleases.push({
+          "@id": "#" + rg.id,
+          "@type": "MusicAlbum",
+          "name": rg.title || '',
+          "artist": artists.join(', '),
+          "image": coverArtUrl(rg.id),
+          "genre": tags.join(', '),
+          "releaseDate": rg['first-release-date'] || '',
+          "releaseYear": extractYear(rg['first-release-date']),
+          "releaseType": rg['primary-type'] || 'Album',
+          "mbid": rg.id,
+          "score": rg.score || 0
+        })
+      })
+      loaded++
+    }).catch(function(err) {
+      console.warn('Failed to load genre ' + genre + ':', err)
+      loaded++
+    })
+  }
+
+  function loadAllGenres(genres, index) {
+    if (index >= genres.length) return Promise.resolve()
+    return loadGenre(genres[index]).then(function() {
+      if (index + 1 < genres.length) {
+        return delay(1100).then(function() {
+          return loadAllGenres(genres, index + 1)
+        })
+      }
+    })
+  }
+
+  loadAllGenres(seedGenres, 0).then(function() {
+    allReleases.sort(function(a, b) { return (b.score || 0) - (a.score || 0) })
+
+    status('Loaded ' + allReleases.length + ' albums')
+
+    var jsonLd = {
+      "@context": context,
+      "@id": "#this",
+      "@type": "MusicCatalog",
+      "title": "MusicBrainz Browser",
+      "releases": allReleases
+    }
+
+    window.__musicData = jsonLd
+    dataEl.textContent = JSON.stringify(jsonLd)
+    document.getElementById('losos').textContent = ''
+
+    var s = document.createElement('script')
+    s.type = 'module'
+    s.src = '../../losos/shell.js'
+    document.body.appendChild(s)
+
+  }).catch(function(err) {
+    console.warn('MusicBrainz load failed:', err)
+    var boot = document.querySelector('.boot-loading')
+    if (boot) {
+      boot.innerHTML =
+        '<div style="font-size: 48px; margin-bottom: 16px;">&#127925;</div>' +
+        '<div style="color: #ef4444;">Failed to load data from MusicBrainz</div>' +
+        '<div style="color: #999; font-size: 14px; margin-top: 8px;">' + err.message + '</div>' +
+        '<button onclick="location.reload()" style="margin-top: 20px; padding: 10px 24px; background: #e11d48; color: #fff; border: none; border-radius: 8px; cursor: pointer; font-size: 14px;">Retry</button>'
+    }
+  })
+})()
+</script>
+</body>
+</html>

--- a/examples/musicbrainz/panes/music-pane.js
+++ b/examples/musicbrainz/panes/music-pane.js
@@ -1,0 +1,487 @@
+import { createStore } from '../../../losos/store.js'
+import { html, render, onUnmount, keyed } from '../../../losos/html.js'
+
+export default {
+  label: 'Browse',
+  icon: '\uD83C\uDFB5',
+
+  canHandle(subject, store) {
+    var node = store.get(subject.value)
+    var type = store.type(node)
+    return type && type.includes('MusicCatalog')
+  },
+
+  render(subject, lionStore, container) {
+    var node = lionStore.get(subject.value)
+    if (!node) return
+
+    var data = window.__musicData
+    if (!data) {
+      var dataEl = document.querySelector('script[type="application/ld+json"]')
+      try { data = JSON.parse(dataEl.textContent) } catch (e) { return }
+    }
+
+    var store = createStore(data)
+    var root = store.get('#this')
+
+    var searchQuery = ''
+    var activeGenre = null
+    var activeType = null
+    var sortBy = 'score'
+    var selected = null
+    var PAGE_SIZE = 60
+    var visibleCount = PAGE_SIZE
+
+    // ========== HELPERS ==========
+
+    function allGenres() {
+      var all = store.propAll(root, 'releases')
+      var counts = {}
+      all.forEach(function(r) {
+        var genres = (r['genre'] || '').split(', ').filter(Boolean)
+        genres.forEach(function(g) {
+          counts[g] = (counts[g] || 0) + 1
+        })
+      })
+      return Object.keys(counts)
+        .sort(function(a, b) { return counts[b] - counts[a] })
+        .slice(0, 20)
+    }
+
+    function allTypes() {
+      var all = store.propAll(root, 'releases')
+      var counts = {}
+      all.forEach(function(r) {
+        var t = r['releaseType'] || 'Album'
+        counts[t] = (counts[t] || 0) + 1
+      })
+      return Object.keys(counts)
+        .sort(function(a, b) { return counts[b] - counts[a] })
+    }
+
+    function matchesSearch(r, q) {
+      return (r['name'] || '').toLowerCase().indexOf(q) !== -1 ||
+             (r['artist'] || '').toLowerCase().indexOf(q) !== -1 ||
+             (r['genre'] || '').toLowerCase().indexOf(q) !== -1
+    }
+
+    function matchesGenre(r, genre) {
+      var genres = (r['genre'] || '').split(', ')
+      return genres.indexOf(genre) !== -1
+    }
+
+    function matchesType(r, type) {
+      return (r['releaseType'] || 'Album') === type
+    }
+
+    function filterReleases() {
+      var all = store.propAll(root, 'releases')
+      var result = all
+
+      if (activeGenre) {
+        result = result.filter(function(r) { return matchesGenre(r, activeGenre) })
+      }
+      if (activeType) {
+        result = result.filter(function(r) { return matchesType(r, activeType) })
+      }
+      if (searchQuery) {
+        var q = searchQuery.toLowerCase()
+        result = result.filter(function(r) { return matchesSearch(r, q) })
+      }
+
+      if (sortBy === 'name') {
+        result.sort(function(a, b) { return (a['name'] || '').localeCompare(b['name'] || '') })
+      } else if (sortBy === 'year') {
+        result.sort(function(a, b) { return (b['releaseYear'] || 0) - (a['releaseYear'] || 0) })
+      } else if (sortBy === 'artist') {
+        result.sort(function(a, b) { return (a['artist'] || '').localeCompare(b['artist'] || '') })
+      }
+      // 'score' keeps original order (by MusicBrainz relevance)
+
+      return result
+    }
+
+    function mbUrl(mbid) {
+      return 'https://musicbrainz.org/release-group/' + mbid
+    }
+
+    // ========== RENDER CARD ==========
+
+    function renderCard(r) {
+      var img = r['image']
+      var yr = r['releaseYear']
+      var genres = (r['genre'] || '').split(', ').filter(Boolean).slice(0, 2)
+      var type = r['releaseType'] || 'Album'
+
+      return html`
+        <div class="mb-card" onclick="${function() { selected = r; renderApp() }}">
+          <div class="mb-card-cover">
+            ${img
+              ? html`<img src="${img}" alt="${r['name']}" loading="lazy"
+                          onerror="${function(e) { e.target.style.display = 'none'; e.target.nextElementSibling.style.display = 'flex' }}" />
+                     <div class="mb-card-no-img" style="display: none;">\uD83C\uDFB5</div>`
+              : html`<div class="mb-card-no-img">\uD83C\uDFB5</div>`
+            }
+          </div>
+          <div class="mb-card-body">
+            <div class="mb-card-title">${r['name']}</div>
+            <div class="mb-card-artist">${r['artist']}</div>
+            <div class="mb-card-meta">
+              ${yr ? html`<span class="mb-card-year">${yr}</span>` : null}
+              ${type !== 'Album' ? html`<span class="mb-card-type">${type}</span>` : null}
+            </div>
+            ${genres.length > 0 ? html`
+              <div class="mb-card-genres">
+                ${genres.map(function(g) { return html`<span class="mb-genre-tag">${g}</span>` })}
+              </div>
+            ` : null}
+          </div>
+        </div>
+      `
+    }
+
+    // ========== RENDER DETAIL MODAL ==========
+
+    function renderDetail(r) {
+      if (!r) return null
+      var yr = r['releaseYear']
+      var genres = (r['genre'] || '').split(', ').filter(Boolean)
+      var type = r['releaseType'] || 'Album'
+
+      return html`
+        <div class="mb-modal-overlay" onclick="${function(e) { if (e.target === e.currentTarget) { selected = null; renderApp() } }}">
+          <div class="mb-modal">
+            <div class="mb-modal-hero">
+              ${r['image']
+                ? html`<img src="${r['image']}" alt="${r['name']}"
+                            onerror="${function(e) { e.target.style.display = 'none'; e.target.nextElementSibling.style.display = 'flex' }}" />
+                       <div class="mb-modal-hero-icon" style="display: none;">\uD83C\uDFB5</div>`
+                : html`<div class="mb-modal-hero-icon">\uD83C\uDFB5</div>`
+              }
+              <button class="mb-modal-close" onclick="${function() { selected = null; renderApp() }}">\u2715</button>
+            </div>
+
+            <div class="mb-modal-body">
+              <h2 class="mb-modal-title">${r['name']}</h2>
+              <div class="mb-modal-artist">${r['artist']}</div>
+
+              <div class="mb-modal-info">
+                ${yr ? html`<span class="mb-modal-year">${yr}</span>` : null}
+                <span class="mb-modal-type">${type}</span>
+              </div>
+
+              ${genres.length > 0 ? html`
+                <div class="mb-modal-genres">
+                  ${genres.map(function(g) { return html`<span class="mb-genre-pill">${g}</span>` })}
+                </div>
+              ` : null}
+
+              ${r['releaseDate'] ? html`
+                <div class="mb-modal-field">
+                  <div class="mb-modal-field-label">Release Date</div>
+                  <div class="mb-modal-field-value">${r['releaseDate']}</div>
+                </div>
+              ` : null}
+
+              <div class="mb-modal-links">
+                <a class="mb-link" href="${mbUrl(r['mbid'])}" target="_blank" rel="noopener">
+                  MusicBrainz \u2197
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      `
+    }
+
+    // ========== MAIN RENDER ==========
+
+    function renderApp() {
+      var filtered = filterReleases()
+      var total = store.propAll(root, 'releases').length
+      var genres = allGenres()
+      var types = allTypes()
+      var visible = filtered.slice(0, visibleCount)
+      var hasMore = filtered.length > visibleCount
+
+      render(container, html`
+        <style>
+          .mb-layout { background: #f5f5f5; min-height: 100vh; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #111; }
+
+          /* Header */
+          .mb-header {
+            background: #fff;
+            border-bottom: 1px solid #e5e5e5;
+            padding: 20px 24px 16px;
+            position: sticky; top: 0; z-index: 50;
+          }
+          .mb-header-inner { max-width: 1400px; margin: 0 auto; }
+          .mb-header-top { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+          .mb-logo { font-size: 22px; font-weight: 700; color: #111; display: flex; align-items: center; gap: 10px; }
+          .mb-logo-icon { font-size: 26px; }
+          .mb-logo-sub { font-size: 12px; color: #999; font-weight: 400; margin-left: 4px; }
+          .mb-count { font-size: 13px; color: #999; margin-left: auto; }
+
+          .mb-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+          .mb-search {
+            flex: 1; min-width: 200px;
+            background: #f5f5f5; border: 1px solid #e0e0e0; border-radius: 10px;
+            padding: 10px 14px; font: 400 14px/1 inherit; color: #111; outline: none;
+            transition: border-color 0.2s;
+          }
+          .mb-search:focus { border-color: #e11d48; background: #fff; }
+          .mb-search::placeholder { color: #aaa; }
+
+          .mb-sort-btn {
+            background: #f5f5f5; border: 1px solid #e0e0e0; border-radius: 8px;
+            padding: 8px 14px; font: 500 13px/1 inherit; color: #666;
+            cursor: pointer; transition: all 0.15s;
+          }
+          .mb-sort-btn:hover { background: #eee; color: #333; }
+          .mb-sort-active { background: #e11d48; color: #fff; border-color: #e11d48; }
+
+          /* Type pills */
+          .mb-types-bar {
+            max-width: 1400px; margin: 10px auto 0;
+            display: flex; gap: 6px; flex-wrap: wrap; padding: 0 24px;
+          }
+          .mb-type-btn {
+            padding: 5px 14px; border-radius: 16px; border: 1px solid #e0e0e0;
+            font: 500 13px/1 inherit; cursor: pointer; transition: all 0.15s;
+            background: #fff; color: #666;
+          }
+          .mb-type-btn:hover { border-color: #ccc; color: #333; }
+          .mb-type-btn-active { background: #7c3aed; color: #fff; border-color: #7c3aed; }
+
+          /* Genre pills */
+          .mb-genres-bar {
+            max-width: 1400px; margin: 8px auto 0;
+            display: flex; gap: 6px; flex-wrap: wrap; padding: 0 24px;
+          }
+          .mb-genre-btn {
+            padding: 5px 14px; border-radius: 16px; border: 1px solid #e0e0e0;
+            font: 500 13px/1 inherit; cursor: pointer; transition: all 0.15s;
+            background: #fff; color: #666;
+          }
+          .mb-genre-btn:hover { border-color: #ccc; color: #333; }
+          .mb-genre-btn-active { background: #e11d48; color: #fff; border-color: #e11d48; }
+
+          /* Body */
+          .mb-body { max-width: 1400px; margin: 0 auto; padding: 16px 24px 60px; }
+          .mb-results { font-size: 13px; color: #999; margin-bottom: 14px; }
+
+          /* Grid */
+          .mb-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 16px;
+          }
+
+          /* Card */
+          .mb-card {
+            background: #fff; border-radius: 12px; overflow: hidden;
+            cursor: pointer; transition: transform 0.3s cubic-bezier(0.16,1,0.3,1), box-shadow 0.3s;
+            border: 1px solid #eee;
+          }
+          .mb-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 8px 24px rgba(0,0,0,0.1);
+          }
+          .mb-card-cover {
+            aspect-ratio: 1; overflow: hidden; background: #f0f0f0;
+            display: flex; align-items: center; justify-content: center;
+          }
+          .mb-card-cover img { width: 100%; height: 100%; object-fit: cover; }
+          .mb-card-no-img {
+            width: 100%; height: 100%;
+            display: flex; align-items: center; justify-content: center;
+            font-size: 48px; color: #ccc; background: linear-gradient(135deg, #f0e6f6 0%, #e6e0f0 100%);
+          }
+          .mb-card-body { padding: 12px 14px 14px; }
+          .mb-card-title {
+            font-size: 14px; font-weight: 600; color: #111;
+            margin-bottom: 2px; line-height: 1.3;
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+          }
+          .mb-card-artist {
+            font-size: 13px; color: #666; margin-bottom: 4px;
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+          }
+          .mb-card-meta {
+            display: flex; gap: 8px; align-items: center;
+            font-size: 12px; color: #888; margin-bottom: 6px;
+          }
+          .mb-card-year { color: #e11d48; font-weight: 500; }
+          .mb-card-type { color: #7c3aed; font-weight: 500; font-size: 11px; }
+          .mb-card-genres { display: flex; gap: 4px; flex-wrap: wrap; }
+          .mb-genre-tag {
+            font-size: 10px; padding: 2px 8px; border-radius: 10px;
+            background: #fef2f2; color: #e11d48; font-weight: 500;
+          }
+
+          /* Load more */
+          .mb-load-more {
+            display: flex; justify-content: center; margin-top: 32px;
+          }
+          .mb-load-more button {
+            padding: 12px 40px; background: #fff; border: 1px solid #e0e0e0;
+            border-radius: 10px; color: #e11d48; font: 500 14px/1 inherit;
+            cursor: pointer; transition: all 0.2s;
+          }
+          .mb-load-more button:hover { background: #fff5f5; border-color: #e11d48; }
+
+          /* Modal */
+          .mb-modal-overlay {
+            position: fixed; inset: 0; z-index: 1000;
+            background: rgba(0,0,0,0.4); backdrop-filter: blur(4px);
+            display: flex; align-items: center; justify-content: center;
+            padding: 20px;
+          }
+          .mb-modal {
+            background: #fff; border-radius: 20px;
+            width: 480px; max-width: 100%; max-height: 90vh;
+            overflow-y: auto; box-shadow: 0 24px 60px rgba(0,0,0,0.15);
+          }
+          .mb-modal-hero {
+            position: relative; aspect-ratio: 1; overflow: hidden;
+            border-radius: 20px 20px 0 0; background: #f0f0f0;
+            display: flex; align-items: center; justify-content: center;
+          }
+          .mb-modal-hero img { width: 100%; height: 100%; object-fit: cover; }
+          .mb-modal-hero-icon { font-size: 80px; color: #ccc; }
+          .mb-modal-close {
+            position: absolute; top: 12px; right: 12px;
+            width: 36px; height: 36px; border-radius: 50%;
+            background: rgba(0,0,0,0.4); border: none; color: #fff;
+            font-size: 16px; cursor: pointer;
+            display: flex; align-items: center; justify-content: center;
+            backdrop-filter: blur(4px); transition: background 0.2s;
+          }
+          .mb-modal-close:hover { background: rgba(0,0,0,0.6); }
+          .mb-modal-body { padding: 24px; }
+          .mb-modal-title { font-size: 26px; font-weight: 700; color: #111; margin-bottom: 2px; line-height: 1.2; }
+          .mb-modal-artist { font-size: 16px; color: #666; margin-bottom: 12px; }
+          .mb-modal-info { display: flex; gap: 12px; align-items: center; margin-bottom: 14px; }
+          .mb-modal-year { font-size: 15px; color: #e11d48; font-weight: 500; }
+          .mb-modal-type {
+            font-size: 12px; font-weight: 600; padding: 3px 10px;
+            border-radius: 12px; background: #f3f0ff; color: #7c3aed;
+          }
+          .mb-modal-genres { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px; }
+          .mb-genre-pill {
+            font-size: 12px; font-weight: 500; padding: 4px 12px;
+            border-radius: 14px; background: #fef2f2; color: #e11d48;
+          }
+          .mb-modal-field { margin-bottom: 12px; }
+          .mb-modal-field-label {
+            font-size: 11px; font-weight: 600; color: #aaa;
+            text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;
+          }
+          .mb-modal-field-value { font-size: 14px; color: #444; }
+          .mb-modal-links {
+            display: flex; gap: 10px; margin-top: 20px; padding-top: 16px;
+            border-top: 1px solid #f0f0f0;
+          }
+          .mb-link {
+            padding: 8px 18px; border-radius: 8px; font-size: 13px; font-weight: 500;
+            text-decoration: none; transition: all 0.2s;
+            background: #fff5f5; color: #e11d48; border: 1px solid #e0e0e0;
+          }
+          .mb-link:hover { background: #fef2f2; border-color: #e11d48; }
+
+          /* Empty state */
+          .mb-empty { text-align: center; padding: 80px 20px; }
+          .mb-empty-icon { font-size: 56px; margin-bottom: 16px; color: #ccc; }
+          .mb-empty-text { color: #999; font-size: 15px; }
+
+          /* Scrollbar */
+          .mb-modal::-webkit-scrollbar { width: 6px; }
+          .mb-modal::-webkit-scrollbar-track { background: transparent; }
+          .mb-modal::-webkit-scrollbar-thumb { background: #ddd; border-radius: 3px; }
+        </style>
+
+        <div class="mb-layout">
+          <div class="mb-header">
+            <div class="mb-header-inner">
+              <div class="mb-header-top">
+                <div class="mb-logo">
+                  <span class="mb-logo-icon">\uD83C\uDFB5</span>
+                  Music Browser
+                  <span class="mb-logo-sub">powered by MusicBrainz</span>
+                </div>
+                <div class="mb-count">${filtered.length} of ${total} albums</div>
+              </div>
+              <div class="mb-controls">
+                <input class="mb-search" type="text" placeholder="Search albums, artists, genres..."
+                       value="${searchQuery}"
+                       oninput="${function(e) { searchQuery = e.target.value; visibleCount = PAGE_SIZE; renderApp() }}" />
+                ${[
+                  { id: 'score', label: 'Relevance' },
+                  { id: 'year', label: 'Newest' },
+                  { id: 'artist', label: 'Artist' },
+                  { id: 'name', label: 'A\u2013Z' }
+                ].map(function(s) {
+                  return html`<button class="${sortBy === s.id ? 'mb-sort-btn mb-sort-active' : 'mb-sort-btn'}"
+                                      onclick="${function() { sortBy = s.id; renderApp() }}">${s.label}</button>`
+                })}
+              </div>
+            </div>
+          </div>
+
+          ${types.length > 1 ? html`
+            <div class="mb-types-bar">
+              <button class="${!activeType ? 'mb-type-btn mb-type-btn-active' : 'mb-type-btn'}"
+                      onclick="${function() { activeType = null; visibleCount = PAGE_SIZE; renderApp() }}">All Types</button>
+              ${types.map(function(t) {
+                var active = activeType === t
+                return html`<button class="${active ? 'mb-type-btn mb-type-btn-active' : 'mb-type-btn'}"
+                                    onclick="${function() { activeType = active ? null : t; visibleCount = PAGE_SIZE; renderApp() }}">${t}</button>`
+              })}
+            </div>
+          ` : null}
+
+          <div class="mb-genres-bar">
+            <button class="${!activeGenre ? 'mb-genre-btn mb-genre-btn-active' : 'mb-genre-btn'}"
+                    onclick="${function() { activeGenre = null; visibleCount = PAGE_SIZE; renderApp() }}">All Genres</button>
+            ${genres.map(function(g) {
+              var active = activeGenre === g
+              return html`<button class="${active ? 'mb-genre-btn mb-genre-btn-active' : 'mb-genre-btn'}"
+                                  onclick="${function() { activeGenre = active ? null : g; visibleCount = PAGE_SIZE; renderApp() }}">${g}</button>`
+            })}
+          </div>
+
+          <div class="mb-body">
+            <div class="mb-results">
+              ${filtered.length} albums${activeGenre ? ' in ' + activeGenre : ''}${activeType ? ' (' + activeType + ')' : ''}${searchQuery ? ' matching \u201C' + searchQuery + '\u201D' : ''}
+            </div>
+
+            ${filtered.length > 0 ? html`
+              <div class="mb-grid">
+                ${keyed(visible, function(r) { return r['@id'] }, function(r) { return renderCard(r) })}
+              </div>
+              ${hasMore ? html`
+                <div class="mb-load-more">
+                  <button onclick="${function() { visibleCount += PAGE_SIZE; renderApp() }}">
+                    Load more (${filtered.length - visibleCount} remaining)
+                  </button>
+                </div>
+              ` : null}
+            ` : html`
+              <div class="mb-empty">
+                <div class="mb-empty-icon">\uD83C\uDFB5</div>
+                <div class="mb-empty-text">No albums found</div>
+              </div>
+            `}
+          </div>
+        </div>
+
+        ${selected ? renderDetail(selected) : null}
+      `)
+    }
+
+    // ========== INIT ==========
+    var unsub = store.onChange(renderApp)
+    setTimeout(renderApp, 0)
+    onUnmount(container, unsub)
+  }
+}

--- a/examples/musicbrainz/panes/source-pane.js
+++ b/examples/musicbrainz/panes/source-pane.js
@@ -1,0 +1,24 @@
+import { html, render } from '../../../losos/html.js'
+
+export default {
+  label: 'Source',
+  icon: '\uD83D\uDCC4',
+
+  canHandle(subject, store) {
+    return store.get(subject.value) != null
+  },
+
+  render(subject, store, container) {
+    var node = store.get(subject.value)
+    if (!node) return
+    var raw = JSON.stringify(node, null, 2)
+
+    render(container, html`
+      <div style="padding: 48px 40px 80px; max-width: 800px; margin: 0 auto; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+        <h2 style="font-size: 22px; font-weight: 600; margin: 0 0 8px; color: #111;">JSON-LD Source</h2>
+        <p style="font-size: 13px; color: #999; margin: 0 0 20px;">Raw linked data from MusicBrainz API</p>
+        <pre style="background: #f8f8fa; padding: 24px; border-radius: 12px; border: 1px solid #e5e5e5; overflow-x: auto; font-family: 'SF Mono', Monaco, Consolas, monospace; font-size: 12px; line-height: 1.6; white-space: pre-wrap; word-break: break-word; color: #e11d48;">${raw}</pre>
+      </div>
+    `)
+  }
+}

--- a/examples/wikidata/index.html
+++ b/examples/wikidata/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TV Series Browser</title>
+  <style>
+    * { margin: 0; box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; color: #111; }
+    #losos { max-width: 100% !important; }
+    #losos > div { max-width: 100% !important; width: 100% !important; }
+    button.pane-tab { color: #999 !important; font-weight: 500 !important; background: transparent !important; border: none; padding: 8px 16px; cursor: pointer; }
+    button.pane-tab[aria-selected="true"] { color: #4f46e5 !important; font-weight: 600 !important; border-bottom: 2px solid #4f46e5 !important; }
+    .boot-loading {
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      height: 80vh; color: #999; font-size: 16px; gap: 20px;
+    }
+    .boot-spinner {
+      width: 44px; height: 44px;
+      border: 3px solid #e5e5e5; border-top-color: #4f46e5;
+      border-radius: 50%; animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .boot-status { font-size: 13px; color: #aaa; }
+  </style>
+</head>
+<body>
+
+<script id="data" type="application/ld+json"></script>
+<script type="module" data-pane src="panes/series-pane.js"></script>
+<script type="module" data-pane src="panes/source-pane.js"></script>
+
+<div id="losos">
+  <div class="boot-loading">
+    <div class="boot-spinner"></div>
+    <div>Loading TV series from Wikidata...</div>
+    <div class="boot-status" id="boot-status"></div>
+  </div>
+</div>
+
+<script>
+(function() {
+  var dataEl = document.getElementById('data')
+  var statusEl = document.getElementById('boot-status')
+  var SPARQL = 'https://query.wikidata.org/sparql'
+
+  var context = {
+    "schema": "http://schema.org/",
+    "dct": "http://purl.org/dc/terms/",
+    "wd": "http://www.wikidata.org/entity/",
+    "title": "dct:title",
+    "series": "schema:hasPart",
+    "name": "schema:name",
+    "description": "schema:description",
+    "image": "schema:image",
+    "genre": "schema:genre",
+    "seasons": "schema:numberOfSeasons",
+    "episodes": "schema:numberOfEpisodes",
+    "startYear": "schema:startDate",
+    "endYear": "schema:endDate",
+    "country": "schema:countryOfOrigin",
+    "network": "schema:broadcaster",
+    "imdb": "schema:sameAs",
+    "wikidataId": "schema:identifier",
+    "isLogo": "schema:isBasedOn",
+    "sitelinks": "schema:interactionCount",
+    "TVCatalog": "schema:WebSite",
+    "TVSeries": "schema:TVSeries"
+  }
+
+  // Main query: TV series ordered by Wikipedia sitelinks (popularity proxy)
+  // Uses P18 (image) with P154 (logo) fallback, plus English Wikipedia sitelink for page images
+  var mainQuery = [
+    'SELECT ?series ?seriesLabel ?description ?image ?logo ?genreLabel',
+    '       ?seasons ?episodes ?startDate ?endDate',
+    '       ?countryLabel ?networkLabel ?imdb ?sl ?enwiki',
+    'WHERE {',
+    '  ?series wdt:P31 wd:Q5398426 .',
+    '  ?series wikibase:sitelinks ?sl .',
+    '  FILTER(?sl > 30)',
+    '  OPTIONAL { ?series wdt:P18 ?image . }',
+    '  OPTIONAL { ?series wdt:P154 ?logo . }',
+    '  OPTIONAL { ?series wdt:P136 ?genre . }',
+    '  OPTIONAL { ?series wdt:P2437 ?seasons . }',
+    '  OPTIONAL { ?series wdt:P1113 ?episodes . }',
+    '  OPTIONAL { ?series wdt:P580 ?startDate . }',
+    '  OPTIONAL { ?series wdt:P582 ?endDate . }',
+    '  OPTIONAL { ?series wdt:P495 ?country . }',
+    '  OPTIONAL { ?series wdt:P449 ?network . }',
+    '  OPTIONAL { ?series wdt:P345 ?imdb . }',
+    '  OPTIONAL { ?series schema:description ?description . FILTER(LANG(?description) = "en") }',
+    '  OPTIONAL { ?enwiki schema:about ?series ; schema:isPartOf <https://en.wikipedia.org/> . }',
+    '  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }',
+    '}',
+    'ORDER BY DESC(?sl)',
+    'LIMIT 1500'
+  ].join('\n')
+
+  function sparqlFetch(q) {
+    return fetch(SPARQL + '?query=' + encodeURIComponent(q), {
+      headers: { 'Accept': 'application/sparql-results+json' }
+    }).then(function(r) {
+      if (!r.ok) throw new Error('SPARQL error: ' + r.status)
+      return r.json()
+    })
+  }
+
+  function val(binding, key) {
+    return binding[key] ? binding[key].value : ''
+  }
+
+  function extractId(uri) {
+    return uri.split('/').pop()
+  }
+
+  function extractYear(dateStr) {
+    if (!dateStr) return null
+    var m = dateStr.match(/(\d{4})/)
+    return m ? parseInt(m[1]) : null
+  }
+
+  function status(msg) {
+    if (statusEl) statusEl.textContent = msg
+  }
+
+  // Fetch Wikipedia page images for series missing Wikidata images
+  // Uses the MediaWiki API with CORS support, batching 50 titles per request
+  function fetchWikipediaImages(titleMap) {
+    var titles = Object.keys(titleMap)
+    if (titles.length === 0) return Promise.resolve()
+
+    var BATCH = 50
+    var batches = []
+    for (var i = 0; i < titles.length; i += BATCH) {
+      batches.push(titles.slice(i, i + BATCH))
+    }
+
+    return Promise.all(batches.map(function(batch) {
+      var url = 'https://en.wikipedia.org/w/api.php?action=query&prop=pageimages'
+        + '&pithumbsize=400&format=json&origin=*&titles='
+        + batch.map(encodeURIComponent).join('|')
+      return fetch(url).then(function(r) { return r.json() }).then(function(data) {
+        var pages = data.query && data.query.pages || {}
+        Object.keys(pages).forEach(function(pid) {
+          var page = pages[pid]
+          if (page.thumbnail && page.thumbnail.source) {
+            var entry = titleMap[page.title]
+            if (entry && !entry.image) {
+              entry.image = page.thumbnail.source
+            }
+          }
+        })
+      }).catch(function() {})
+    }))
+  }
+
+  status('Querying Wikidata SPARQL endpoint...')
+
+  sparqlFetch(mainQuery).then(function(result) {
+    var bindings = result.results.bindings
+    status('Processing ' + bindings.length + ' results...')
+
+    // Group by series URI, merge multi-valued fields
+    var seriesMap = {}
+    var order = []
+
+    bindings.forEach(function(b) {
+      var uri = b.series.value
+      var id = extractId(uri)
+      var label = val(b, 'seriesLabel') || id
+
+      // Skip items whose label is just a Q-number (no English label)
+      if (/^Q\d+$/.test(label)) return
+
+      if (!seriesMap[uri]) {
+        seriesMap[uri] = {
+          "@id": "#" + id,
+          "@type": "TVSeries",
+          "name": label,
+          "description": val(b, 'description'),
+          "image": val(b, 'image'),
+          "isLogo": false,
+          "_logo": val(b, 'logo'),
+          "genre": [],
+          "seasons": b.seasons ? parseInt(b.seasons.value) : null,
+          "episodes": b.episodes ? parseInt(b.episodes.value) : null,
+          "startYear": extractYear(val(b, 'startDate')),
+          "endYear": extractYear(val(b, 'endDate')),
+          "country": [],
+          "network": [],
+          "imdb": val(b, 'imdb'),
+          "wikidataId": id,
+          "sitelinks": b.sl ? parseInt(b.sl.value) : 0,
+          "_wpTitle": ''
+        }
+        order.push(uri)
+      }
+
+      var entry = seriesMap[uri]
+
+      // Pick up P18 image from later rows if first row was empty
+      if (!entry.image) {
+        var img = val(b, 'image')
+        if (img) entry.image = img
+      }
+      // Collect logo separately
+      if (!entry._logo) {
+        var logo = val(b, 'logo')
+        if (logo) entry._logo = logo
+      }
+
+      // Capture Wikipedia article title from sitelink URL
+      if (!entry._wpTitle && b.enwiki) {
+        var wpUrl = b.enwiki.value
+        var wpTitle = decodeURIComponent(wpUrl.replace('https://en.wikipedia.org/wiki/', ''))
+        entry._wpTitle = wpTitle
+      }
+
+      // Collect unique genres
+      var g = val(b, 'genreLabel')
+      if (g && entry.genre.indexOf(g) === -1) entry.genre.push(g)
+
+      // Collect unique countries
+      var c = val(b, 'countryLabel')
+      if (c && entry.country.indexOf(c) === -1) entry.country.push(c)
+
+      // Collect unique networks
+      var n = val(b, 'networkLabel')
+      if (n && entry.network.indexOf(n) === -1) entry.network.push(n)
+    })
+
+    // Fetch Wikipedia images for ALL series without a P18 photo
+    var wpTitleMap = {}
+    order.forEach(function(uri) {
+      var entry = seriesMap[uri]
+      if (!entry.image && entry._wpTitle) {
+        wpTitleMap[entry._wpTitle] = entry
+      }
+    })
+
+    var missingCount = Object.keys(wpTitleMap).length
+    if (missingCount > 0) {
+      status('Fetching ' + missingCount + ' images from Wikipedia...')
+    }
+
+    return fetchWikipediaImages(wpTitleMap).then(function() {
+      // Final fallback: use P154 logo for series still without any image
+      order.forEach(function(uri) {
+        var entry = seriesMap[uri]
+        if (!entry.image && entry._logo) {
+          entry.image = entry._logo
+          entry.isLogo = true
+        }
+      })
+
+      // Convert arrays to comma-separated strings, remove internal fields
+      var seriesList = order.map(function(uri) {
+        var s = seriesMap[uri]
+        s.genre = s.genre.join(', ')
+        s.country = s.country.join(', ')
+        s.network = s.network.join(', ')
+        delete s._wpTitle
+        delete s._logo
+        return s
+      })
+
+      status('Loaded ' + seriesList.length + ' TV series')
+
+      var jsonLd = {
+        "@context": context,
+        "@id": "#this",
+        "@type": "TVCatalog",
+        "title": "TV Series Browser",
+        "series": seriesList
+      }
+
+      window.__seriesData = jsonLd
+      dataEl.textContent = JSON.stringify(jsonLd)
+      document.getElementById('losos').textContent = ''
+
+      var s = document.createElement('script')
+      s.type = 'module'
+      s.src = '../../losos/shell.js'
+      document.body.appendChild(s)
+    })
+
+  }).catch(function(err) {
+    console.warn('Wikidata query failed:', err)
+    var boot = document.querySelector('.boot-loading')
+    if (boot) {
+      boot.innerHTML =
+        '<div style="font-size: 48px; margin-bottom: 16px;">&#128250;</div>' +
+        '<div style="color: #ef4444;">Failed to load data from Wikidata</div>' +
+        '<div style="color: #999; font-size: 14px; margin-top: 8px;">' + err.message + '</div>' +
+        '<button onclick="location.reload()" style="margin-top: 20px; padding: 10px 24px; background: #4f46e5; color: #fff; border: none; border-radius: 8px; cursor: pointer; font-size: 14px;">Retry</button>'
+    }
+  })
+})()
+</script>
+</body>
+</html>

--- a/examples/wikidata/panes/series-pane.js
+++ b/examples/wikidata/panes/series-pane.js
@@ -1,0 +1,521 @@
+import { createStore } from '../../../losos/store.js'
+import { html, render, onUnmount, keyed } from '../../../losos/html.js'
+
+export default {
+  label: 'Browse',
+  icon: '\uD83D\uDCFA',
+
+  canHandle(subject, store) {
+    var node = store.get(subject.value)
+    var type = store.type(node)
+    return type && type.includes('TVCatalog')
+  },
+
+  render(subject, lionStore, container) {
+    var node = lionStore.get(subject.value)
+    if (!node) return
+
+    var data = window.__seriesData
+    if (!data) {
+      var dataEl = document.querySelector('script[type="application/ld+json"]')
+      try { data = JSON.parse(dataEl.textContent) } catch (e) { return }
+    }
+
+    var store = createStore(data)
+    var root = store.get('#this')
+
+    var searchQuery = ''
+    var activeGenre = null
+    var sortBy = 'popular'
+    var selected = null
+    var PAGE_SIZE = 60
+    var visibleCount = PAGE_SIZE
+
+    // ========== HELPERS ==========
+
+    function allGenres() {
+      var all = store.propAll(root, 'series')
+      var counts = {}
+      all.forEach(function(s) {
+        var genres = (s['genre'] || '').split(', ').filter(Boolean)
+        genres.forEach(function(g) {
+          counts[g] = (counts[g] || 0) + 1
+        })
+      })
+      return Object.keys(counts)
+        .sort(function(a, b) { return counts[b] - counts[a] })
+        .slice(0, 20)
+    }
+
+    function matchesSearch(s, q) {
+      return (s['name'] || '').toLowerCase().indexOf(q) !== -1 ||
+             (s['description'] || '').toLowerCase().indexOf(q) !== -1 ||
+             (s['network'] || '').toLowerCase().indexOf(q) !== -1 ||
+             (s['country'] || '').toLowerCase().indexOf(q) !== -1
+    }
+
+    function matchesGenre(s, genre) {
+      var genres = (s['genre'] || '').split(', ')
+      return genres.indexOf(genre) !== -1
+    }
+
+    function filterSeries() {
+      var all = store.propAll(root, 'series')
+      var result = all
+
+      if (activeGenre) {
+        result = result.filter(function(s) { return matchesGenre(s, activeGenre) })
+      }
+      if (searchQuery) {
+        var q = searchQuery.toLowerCase()
+        result = result.filter(function(s) { return matchesSearch(s, q) })
+      }
+
+      if (sortBy === 'name') {
+        result.sort(function(a, b) { return (a['name'] || '').localeCompare(b['name'] || '') })
+      } else if (sortBy === 'year') {
+        result.sort(function(a, b) { return (b['startYear'] || 0) - (a['startYear'] || 0) })
+      } else if (sortBy === 'episodes') {
+        result.sort(function(a, b) { return (b['episodes'] || 0) - (a['episodes'] || 0) })
+      }
+
+      return result
+    }
+
+    function yearRange(s) {
+      if (!s['startYear']) return ''
+      if (s['endYear'] && s['endYear'] !== s['startYear']) {
+        return s['startYear'] + '\u2013' + s['endYear']
+      }
+      return String(s['startYear'])
+    }
+
+    function formatEpisodes(n) {
+      if (!n) return ''
+      return n + ' ep' + (n !== 1 ? 's' : '')
+    }
+
+    function wikidataUrl(id) {
+      return 'https://www.wikidata.org/wiki/' + id
+    }
+
+    function imdbUrl(id) {
+      if (!id) return ''
+      return 'https://www.imdb.com/title/' + id + '/'
+    }
+
+    function thumbUrl(imageUrl) {
+      if (!imageUrl) return ''
+      if (imageUrl.indexOf('commons.wikimedia.org') !== -1 || imageUrl.indexOf('upload.wikimedia.org') !== -1) {
+        if (imageUrl.indexOf('Special:FilePath') !== -1) {
+          return imageUrl + '?width=400'
+        }
+        return imageUrl.replace('/commons/', '/commons/thumb/') + '/400px-' + imageUrl.split('/').pop()
+      }
+      return imageUrl
+    }
+
+    // ========== RENDER CARD ==========
+
+    function renderCard(s) {
+      var img = s['image']
+      var isLogo = s['isLogo'] === true
+      var yr = yearRange(s)
+      var genres = (s['genre'] || '').split(', ').filter(Boolean).slice(0, 2)
+      var posterClass = isLogo ? 'tv-card-poster tv-card-poster-logo' : 'tv-card-poster'
+
+      return html`
+        <div class="tv-card" onclick="${function() { selected = s; renderApp() }}">
+          <div class="${posterClass}">
+            ${img
+              ? html`<img src="${thumbUrl(img)}" alt="${s['name']}" loading="lazy"
+                          onerror="${function(e) { e.target.style.display = 'none'; e.target.nextElementSibling.style.display = 'flex' }}" />
+                     <div class="tv-card-no-img" style="display: none;">\uD83D\uDCFA</div>`
+              : html`<div class="tv-card-no-img">\uD83D\uDCFA</div>`
+            }
+          </div>
+          <div class="tv-card-body">
+            <div class="tv-card-title">${s['name']}</div>
+            <div class="tv-card-meta">
+              ${yr ? html`<span class="tv-card-year">${yr}</span>` : null}
+              ${s['episodes'] ? html`<span class="tv-card-eps">${formatEpisodes(s['episodes'])}</span>` : null}
+            </div>
+            ${genres.length > 0 ? html`
+              <div class="tv-card-genres">
+                ${genres.map(function(g) { return html`<span class="tv-genre-tag">${g}</span>` })}
+              </div>
+            ` : null}
+          </div>
+        </div>
+      `
+    }
+
+    // ========== RENDER DETAIL MODAL ==========
+
+    function renderDetail(s) {
+      if (!s) return null
+      var yr = yearRange(s)
+      var isLogo = s['isLogo'] === true
+      var genres = (s['genre'] || '').split(', ').filter(Boolean)
+      var networks = (s['network'] || '').split(', ').filter(Boolean)
+      var countries = (s['country'] || '').split(', ').filter(Boolean)
+      var heroClass = s['image'] ? (isLogo ? 'tv-modal-hero tv-modal-hero-logo' : 'tv-modal-hero') : 'tv-modal-hero tv-modal-hero-empty'
+
+      return html`
+        <div class="tv-modal-overlay" onclick="${function(e) { if (e.target === e.currentTarget) { selected = null; renderApp() } }}">
+          <div class="tv-modal">
+            ${s['image'] ? html`
+              <div class="${heroClass}">
+                <img src="${thumbUrl(s['image'])}" alt="${s['name']}" />
+                ${isLogo ? null : html`<div class="tv-modal-hero-gradient"></div>`}
+                <button class="tv-modal-close" onclick="${function() { selected = null; renderApp() }}">\u2715</button>
+              </div>
+            ` : html`
+              <div class="${heroClass}">
+                <div class="tv-modal-hero-icon">\uD83D\uDCFA</div>
+                <button class="tv-modal-close" onclick="${function() { selected = null; renderApp() }}">\u2715</button>
+              </div>
+            `}
+
+            <div class="tv-modal-body">
+              <h2 class="tv-modal-title">${s['name']}</h2>
+              ${yr ? html`<div class="tv-modal-year">${yr}</div>` : null}
+
+              ${genres.length > 0 ? html`
+                <div class="tv-modal-genres">
+                  ${genres.map(function(g) { return html`<span class="tv-genre-pill">${g}</span>` })}
+                </div>
+              ` : null}
+
+              ${s['description'] ? html`
+                <p class="tv-modal-desc">${s['description']}</p>
+              ` : null}
+
+              <div class="tv-modal-stats">
+                ${s['episodes'] ? html`
+                  <div class="tv-stat">
+                    <div class="tv-stat-value">${s['episodes']}</div>
+                    <div class="tv-stat-label">Episodes</div>
+                  </div>
+                ` : null}
+                ${s['seasons'] ? html`
+                  <div class="tv-stat">
+                    <div class="tv-stat-value">${s['seasons']}</div>
+                    <div class="tv-stat-label">Seasons</div>
+                  </div>
+                ` : null}
+                ${s['sitelinks'] ? html`
+                  <div class="tv-stat">
+                    <div class="tv-stat-value">${s['sitelinks']}</div>
+                    <div class="tv-stat-label">Wiki Links</div>
+                  </div>
+                ` : null}
+              </div>
+
+              ${networks.length > 0 ? html`
+                <div class="tv-modal-field">
+                  <div class="tv-modal-field-label">Network</div>
+                  <div class="tv-modal-field-value">${networks.join(', ')}</div>
+                </div>
+              ` : null}
+
+              ${countries.length > 0 ? html`
+                <div class="tv-modal-field">
+                  <div class="tv-modal-field-label">Country</div>
+                  <div class="tv-modal-field-value">${countries.join(', ')}</div>
+                </div>
+              ` : null}
+
+              <div class="tv-modal-links">
+                <a class="tv-link" href="${wikidataUrl(s['wikidataId'])}" target="_blank" rel="noopener">
+                  Wikidata \u2197
+                </a>
+                ${s['imdb'] ? html`
+                  <a class="tv-link tv-link-imdb" href="${imdbUrl(s['imdb'])}" target="_blank" rel="noopener">
+                    IMDb \u2197
+                  </a>
+                ` : null}
+              </div>
+            </div>
+          </div>
+        </div>
+      `
+    }
+
+    // ========== MAIN RENDER ==========
+
+    function renderApp() {
+      var filtered = filterSeries()
+      var total = store.propAll(root, 'series').length
+      var genres = allGenres()
+      var visible = filtered.slice(0, visibleCount)
+      var hasMore = filtered.length > visibleCount
+
+      render(container, html`
+        <style>
+          .tv-layout { background: #f5f5f5; min-height: 100vh; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #111; }
+
+          /* Header */
+          .tv-header {
+            background: #fff;
+            border-bottom: 1px solid #e5e5e5;
+            padding: 20px 24px 16px;
+            position: sticky; top: 0; z-index: 50;
+          }
+          .tv-header-inner { max-width: 1400px; margin: 0 auto; }
+          .tv-header-top { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+          .tv-logo { font-size: 22px; font-weight: 700; color: #111; display: flex; align-items: center; gap: 10px; }
+          .tv-logo-icon { font-size: 26px; }
+          .tv-logo-sub { font-size: 12px; color: #999; font-weight: 400; margin-left: 4px; }
+          .tv-count { font-size: 13px; color: #999; margin-left: auto; }
+
+          .tv-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+          .tv-search {
+            flex: 1; min-width: 200px;
+            background: #f5f5f5; border: 1px solid #e0e0e0; border-radius: 10px;
+            padding: 10px 14px; font: 400 14px/1 inherit; color: #111; outline: none;
+            transition: border-color 0.2s;
+          }
+          .tv-search:focus { border-color: #4f46e5; background: #fff; }
+          .tv-search::placeholder { color: #aaa; }
+
+          .tv-sort-btn {
+            background: #f5f5f5; border: 1px solid #e0e0e0; border-radius: 8px;
+            padding: 8px 14px; font: 500 13px/1 inherit; color: #666;
+            cursor: pointer; transition: all 0.15s;
+          }
+          .tv-sort-btn:hover { background: #eee; color: #333; }
+          .tv-sort-active { background: #4f46e5; color: #fff; border-color: #4f46e5; }
+
+          /* Genre pills */
+          .tv-genres-bar {
+            max-width: 1400px; margin: 12px auto 0;
+            display: flex; gap: 6px; flex-wrap: wrap; padding: 0 24px;
+          }
+          .tv-genre-btn {
+            padding: 5px 14px; border-radius: 16px; border: 1px solid #e0e0e0;
+            font: 500 13px/1 inherit; cursor: pointer; transition: all 0.15s;
+            background: #fff; color: #666;
+          }
+          .tv-genre-btn:hover { border-color: #ccc; color: #333; }
+          .tv-genre-btn-active { background: #4f46e5; color: #fff; border-color: #4f46e5; }
+
+          /* Body */
+          .tv-body { max-width: 1400px; margin: 0 auto; padding: 16px 24px 60px; }
+          .tv-results { font-size: 13px; color: #999; margin-bottom: 14px; }
+
+          /* Grid */
+          .tv-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            gap: 16px;
+          }
+
+          /* Card */
+          .tv-card {
+            background: #fff; border-radius: 12px; overflow: hidden;
+            cursor: pointer; transition: transform 0.3s cubic-bezier(0.16,1,0.3,1), box-shadow 0.3s;
+            border: 1px solid #eee;
+          }
+          .tv-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 8px 24px rgba(0,0,0,0.1);
+          }
+          .tv-card-poster {
+            height: 160px; overflow: hidden; background: #f0f0f0;
+            display: flex; align-items: center; justify-content: center;
+          }
+          .tv-card-poster img { width: 100%; height: 100%; object-fit: cover; }
+          .tv-card-poster-logo { background: #eef0f8; }
+          .tv-card-poster-logo img { object-fit: contain !important; padding: 20px; }
+          .tv-card-no-img {
+            width: 100%; height: 100%;
+            display: flex; align-items: center; justify-content: center;
+            font-size: 48px; color: #ccc; background: #f5f5f5;
+          }
+          .tv-card-body { padding: 12px 14px 14px; }
+          .tv-card-title {
+            font-size: 14px; font-weight: 600; color: #111;
+            margin-bottom: 4px; line-height: 1.3;
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+          }
+          .tv-card-meta {
+            display: flex; gap: 8px; align-items: center;
+            font-size: 12px; color: #888; margin-bottom: 6px;
+          }
+          .tv-card-year { color: #4f46e5; font-weight: 500; }
+          .tv-card-eps { color: #999; }
+          .tv-card-genres { display: flex; gap: 4px; flex-wrap: wrap; }
+          .tv-genre-tag {
+            font-size: 10px; padding: 2px 8px; border-radius: 10px;
+            background: #eef0ff; color: #4f46e5; font-weight: 500;
+          }
+
+          /* Load more */
+          .tv-load-more {
+            display: flex; justify-content: center; margin-top: 32px;
+          }
+          .tv-load-more button {
+            padding: 12px 40px; background: #fff; border: 1px solid #e0e0e0;
+            border-radius: 10px; color: #4f46e5; font: 500 14px/1 inherit;
+            cursor: pointer; transition: all 0.2s;
+          }
+          .tv-load-more button:hover { background: #f5f5ff; border-color: #4f46e5; }
+
+          /* Modal */
+          .tv-modal-overlay {
+            position: fixed; inset: 0; z-index: 1000;
+            background: rgba(0,0,0,0.4); backdrop-filter: blur(4px);
+            display: flex; align-items: center; justify-content: center;
+            padding: 20px;
+          }
+          .tv-modal {
+            background: #fff; border-radius: 20px;
+            width: 520px; max-width: 100%; max-height: 90vh;
+            overflow-y: auto; box-shadow: 0 24px 60px rgba(0,0,0,0.15);
+          }
+          .tv-modal-hero {
+            position: relative; height: 240px; overflow: hidden;
+            border-radius: 20px 20px 0 0; background: #f0f0f0;
+          }
+          .tv-modal-hero img { width: 100%; height: 100%; object-fit: cover; }
+          .tv-modal-hero-logo { background: #eef0f8; }
+          .tv-modal-hero-logo img { object-fit: contain !important; padding: 32px; }
+          .tv-modal-hero-gradient {
+            position: absolute; inset: 0;
+            background: linear-gradient(180deg, transparent 40%, rgba(255,255,255,0.9) 100%);
+          }
+          .tv-modal-hero-empty {
+            display: flex; align-items: center; justify-content: center;
+          }
+          .tv-modal-hero-icon { font-size: 64px; color: #ccc; }
+          .tv-modal-close {
+            position: absolute; top: 12px; right: 12px;
+            width: 36px; height: 36px; border-radius: 50%;
+            background: rgba(0,0,0,0.4); border: none; color: #fff;
+            font-size: 16px; cursor: pointer;
+            display: flex; align-items: center; justify-content: center;
+            backdrop-filter: blur(4px); transition: background 0.2s;
+          }
+          .tv-modal-close:hover { background: rgba(0,0,0,0.6); }
+          .tv-modal-body { padding: 24px; }
+          .tv-modal-title { font-size: 26px; font-weight: 700; color: #111; margin-bottom: 4px; line-height: 1.2; }
+          .tv-modal-year { font-size: 15px; color: #4f46e5; font-weight: 500; margin-bottom: 12px; }
+          .tv-modal-genres { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px; }
+          .tv-genre-pill {
+            font-size: 12px; font-weight: 500; padding: 4px 12px;
+            border-radius: 14px; background: #eef0ff; color: #4f46e5;
+          }
+          .tv-modal-desc {
+            font-size: 14px; color: #666; line-height: 1.6; margin-bottom: 20px;
+          }
+          .tv-modal-stats {
+            display: flex; gap: 24px; margin-bottom: 20px;
+            padding-bottom: 20px; border-bottom: 1px solid #f0f0f0;
+          }
+          .tv-stat { text-align: center; }
+          .tv-stat-value { font-size: 22px; font-weight: 700; color: #111; }
+          .tv-stat-label { font-size: 11px; color: #999; text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
+          .tv-modal-field { margin-bottom: 12px; }
+          .tv-modal-field-label {
+            font-size: 11px; font-weight: 600; color: #aaa;
+            text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 2px;
+          }
+          .tv-modal-field-value { font-size: 14px; color: #444; }
+          .tv-modal-links {
+            display: flex; gap: 10px; margin-top: 20px; padding-top: 16px;
+            border-top: 1px solid #f0f0f0;
+          }
+          .tv-link {
+            padding: 8px 18px; border-radius: 8px; font-size: 13px; font-weight: 500;
+            text-decoration: none; transition: all 0.2s;
+            background: #f5f5ff; color: #4f46e5; border: 1px solid #e0e0e0;
+          }
+          .tv-link:hover { background: #eef0ff; border-color: #4f46e5; }
+          .tv-link-imdb { color: #b45309; background: #fffbeb; }
+          .tv-link-imdb:hover { border-color: #b45309; }
+
+          /* Empty state */
+          .tv-empty { text-align: center; padding: 80px 20px; }
+          .tv-empty-icon { font-size: 56px; margin-bottom: 16px; color: #ccc; }
+          .tv-empty-text { color: #999; font-size: 15px; }
+
+          /* Scrollbar */
+          .tv-modal::-webkit-scrollbar { width: 6px; }
+          .tv-modal::-webkit-scrollbar-track { background: transparent; }
+          .tv-modal::-webkit-scrollbar-thumb { background: #ddd; border-radius: 3px; }
+        </style>
+
+        <div class="tv-layout">
+          <div class="tv-header">
+            <div class="tv-header-inner">
+              <div class="tv-header-top">
+                <div class="tv-logo">
+                  <span class="tv-logo-icon">\uD83D\uDCFA</span>
+                  TV Series
+                  <span class="tv-logo-sub">powered by Wikidata</span>
+                </div>
+                <div class="tv-count">${filtered.length} of ${total} series</div>
+              </div>
+              <div class="tv-controls">
+                <input class="tv-search" type="text" placeholder="Search series, networks, countries..."
+                       value="${searchQuery}"
+                       oninput="${function(e) { searchQuery = e.target.value; visibleCount = PAGE_SIZE; renderApp() }}" />
+                ${[
+                  { id: 'popular', label: 'Popular' },
+                  { id: 'year', label: 'Newest' },
+                  { id: 'episodes', label: 'Episodes' },
+                  { id: 'name', label: 'A\u2013Z' }
+                ].map(function(s) {
+                  return html`<button class="${sortBy === s.id ? 'tv-sort-btn tv-sort-active' : 'tv-sort-btn'}"
+                                      onclick="${function() { sortBy = s.id; renderApp() }}">${s.label}</button>`
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div class="tv-genres-bar">
+            <button class="${!activeGenre ? 'tv-genre-btn tv-genre-btn-active' : 'tv-genre-btn'}"
+                    onclick="${function() { activeGenre = null; visibleCount = PAGE_SIZE; renderApp() }}">All</button>
+            ${genres.map(function(g) {
+              var active = activeGenre === g
+              return html`<button class="${active ? 'tv-genre-btn tv-genre-btn-active' : 'tv-genre-btn'}"
+                                  onclick="${function() { activeGenre = active ? null : g; visibleCount = PAGE_SIZE; renderApp() }}">${g}</button>`
+            })}
+          </div>
+
+          <div class="tv-body">
+            <div class="tv-results">
+              ${filtered.length} series${activeGenre ? ' in ' + activeGenre : ''}${searchQuery ? ' matching \u201C' + searchQuery + '\u201D' : ''}
+            </div>
+
+            ${filtered.length > 0 ? html`
+              <div class="tv-grid">
+                ${keyed(visible, function(s) { return s['@id'] }, function(s) { return renderCard(s) })}
+              </div>
+              ${hasMore ? html`
+                <div class="tv-load-more">
+                  <button onclick="${function() { visibleCount += PAGE_SIZE; renderApp() }}">
+                    Load more (${filtered.length - visibleCount} remaining)
+                  </button>
+                </div>
+              ` : null}
+            ` : html`
+              <div class="tv-empty">
+                <div class="tv-empty-icon">\uD83D\uDCFA</div>
+                <div class="tv-empty-text">No series found</div>
+              </div>
+            `}
+          </div>
+        </div>
+
+        ${selected ? renderDetail(selected) : null}
+      `)
+    }
+
+    // ========== INIT ==========
+    var unsub = store.onChange(renderApp)
+    setTimeout(renderApp, 0)
+    onUnmount(container, unsub)
+  }
+}

--- a/examples/wikidata/panes/source-pane.js
+++ b/examples/wikidata/panes/source-pane.js
@@ -1,0 +1,24 @@
+import { html, render } from '../../../losos/html.js'
+
+export default {
+  label: 'Source',
+  icon: '\uD83D\uDCC4',
+
+  canHandle(subject, store) {
+    return store.get(subject.value) != null
+  },
+
+  render(subject, store, container) {
+    var node = store.get(subject.value)
+    if (!node) return
+    var raw = JSON.stringify(node, null, 2)
+
+    render(container, html`
+      <div style="padding: 48px 40px 80px; max-width: 800px; margin: 0 auto; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+        <h2 style="font-size: 22px; font-weight: 600; margin: 0 0 8px; color: #111;">JSON-LD Source</h2>
+        <p style="font-size: 13px; color: #999; margin: 0 0 20px;">Raw linked data from Wikidata SPARQL</p>
+        <pre style="background: #f8f8fa; padding: 24px; border-radius: 12px; border: 1px solid #e5e5e5; overflow-x: auto; font-family: 'SF Mono', Monaco, Consolas, monospace; font-size: 12px; line-height: 1.6; white-space: pre-wrap; word-break: break-word; color: #4f46e5;">${raw}</pre>
+      </div>
+    `)
+  }
+}


### PR DESCRIPTION
## Summary
- **Wikidata TV Series Browser**: 300+ TV series from Wikidata SPARQL with Wikipedia image fallback, genre filters, search, and detail modal with IMDb links
- **MusicBrainz Album Browser**: Albums across 10 genre seeds (rock, pop, jazz, electronic, hip hop, classical, soul, metal, folk, blues) from MusicBrainz API with cover art from Cover Art Archive, genre/type filters, search, sort, and detail modal
- Updated examples gallery index with cards for both new apps

Closes #1

## Test plan
- [ ] Open `examples/wikidata/` — verify TV series load from Wikidata SPARQL, genre filter and search work, detail modal shows IMDb link
- [ ] Open `examples/musicbrainz/` — verify albums load progressively across genre seeds, cover art displays from Cover Art Archive, genre/type filters work, sort options work, detail modal links to MusicBrainz
- [ ] Open `examples/index.html` — verify both new cards appear in the Apps section