### PR TITLE
README: add Vocabulary section recommending urn:solid

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ No build step. No dependencies. No virtual DOM.
 
 Create `index.html`, copy the code from the [Quick Start](https://losos.org/docs/quickstart.html), open in browser. That's it.
 
+## Vocabulary
+
+LOSOS data is JSON-LD. When no explicit `@context` is supplied, the recommended default vocabulary is `urn:solid:` — a stable, vocabulary-agnostic surface that maps (via `owl:sameAs`) to the canonical IRIs in FOAF, Schema.org, dcterms, ActivityStreams, and other common vocabularies.
+
+This means panes can register against `urn:solid:` types (e.g. `urn:solid:Person`) and match data regardless of which upstream vocabulary the source app used. Pods are vocab-heterogeneous; `urn:solid` is the indirection layer that lets a single pane handle every variant.
+
+- Registry (~440 terms): https://urn-solid.github.io/
+- Namespace specification: https://urn-solid.github.io/spec/
+- LION's matching recommendation: https://github.com/linkedobjects/linkedobjects#rdf-compatibility
+
 ## Links
 
 - **Website:** https://losos.org


### PR DESCRIPTION
Smaller follow-through on #6 — adds a brief \`## Vocabulary\` section to the README between Quick Start and Links.

## Summary

- Documents the recommended default vocabulary (\`urn:solid:\`) for LOSOS data with no explicit \`@context\`.
- Spells out the LOSOS-specific payoff: panes register against \`urn:solid:\` types once and match heterogeneous pod data regardless of upstream vocabulary.
- Cross-links the urn:solid registry, spec, and the matching LION recommendation.

## Scope

Documentation only. Doesn't change any pane API, runtime behaviour, or registration syntax — those design questions remain open in #6 and can be tackled in a separate PR.

## Test plan

- [ ] Render the README and confirm the new section reads cleanly between Quick Start and Links.
- [ ] Verify all three links resolve.