### PR TITLE
Add urn:solid resolver as standalone opt-in module (no shell changes)

### DIFF
--- a/losos/shell.js
+++ b/losos/shell.js
@@ -5,13 +5,12 @@
 
 import { createStore } from '../lion/index.js'
 import defaultRegistry from './registry.js'
-import { loadIndex as loadUrnSolidIndex, resolve as resolveUrnSolid } from './urn-solid-resolver.js'
 
 // Module-level state — available to resolvePane after boot
 var _panes = []
 var _registry = Object.assign({}, defaultRegistry)
 var _paneCache = new Map()  // url → pane module
-var _urnSolidIndex = null   // populated lazily on first registry lookup
+var _typeResolver = null    // optional async fn(type) → canonicalType (e.g. urn:solid resolver)
 
 /** Load all registered panes from data-pane script tags */
 async function loadPanes() {
@@ -252,18 +251,21 @@ export async function resolvePane(node, store, container, rawData, opts) {
   }
 
   // 3. Registry — @type → pane URL
-  // Try direct match first (preserves existing registrations like 'wf:Tracker'),
-  // then fall back to the urn:solid canonical form so a pane registered against
-  // 'urn:solid:Person' also matches incoming 'foaf:Person', 'schema:Person', etc.
+  // Try direct match first (preserves existing registrations like 'wf:Tracker').
+  // If a type resolver was wired in (e.g. setTypeResolver(urnSolid.resolveType)),
+  // try the canonical form on miss — lets one pane match many upstream IRIs.
   var type = node['@type']
   var regUrl = null
   if (type) {
     if (registry[type]) {
       regUrl = registry[type]
-    } else {
-      if (!_urnSolidIndex) _urnSolidIndex = await loadUrnSolidIndex()
-      var canonical = resolveUrnSolid(type, _urnSolidIndex)
-      if (canonical !== type && registry[canonical]) regUrl = registry[canonical]
+    } else if (_typeResolver) {
+      try {
+        var canonical = await _typeResolver(type)
+        if (canonical && canonical !== type && registry[canonical]) regUrl = registry[canonical]
+      } catch (err) {
+        console.warn('[losos] type resolver failed:', type, err)
+      }
     }
   }
   if (regUrl) {
@@ -311,6 +313,19 @@ export async function boot(el, opts) {
 
 /** Access/extend the registry */
 export { _registry as registry }
+
+/** Wire in an optional type resolver — async fn(type) returning a canonical
+ *  form to retry registry lookup with. Call once at app startup, before boot.
+ *  Pass null to clear.
+ *
+ *  Example (urn:solid resolution):
+ *    import { setTypeResolver } from './losos/shell.js'
+ *    import { resolveType } from './losos/urn-solid-resolver.js'
+ *    setTypeResolver(resolveType)
+ */
+export function setTypeResolver(fn) {
+  _typeResolver = fn
+}
 
 // Auto-boot if a known container exists
 if (document.getElementById('solid') || document.getElementById('losos') || document.getElementById('mashlib') || document.getElementById('app')) {

--- a/losos/shell.js
+++ b/losos/shell.js
@@ -10,7 +10,6 @@ import defaultRegistry from './registry.js'
 var _panes = []
 var _registry = Object.assign({}, defaultRegistry)
 var _paneCache = new Map()  // url → pane module
-var _typeResolver = null    // optional async fn(type) → canonicalType (e.g. urn:solid resolver)
 
 /** Load all registered panes from data-pane script tags */
 async function loadPanes() {
@@ -251,24 +250,9 @@ export async function resolvePane(node, store, container, rawData, opts) {
   }
 
   // 3. Registry — @type → pane URL
-  // Try direct match first (preserves existing registrations like 'wf:Tracker').
-  // If a type resolver was wired in (e.g. setTypeResolver(urnSolid.resolveType)),
-  // try the canonical form on miss — lets one pane match many upstream IRIs.
   var type = node['@type']
-  var regUrl = null
-  if (type) {
-    if (registry[type]) {
-      regUrl = registry[type]
-    } else if (_typeResolver) {
-      try {
-        var canonical = await _typeResolver(type)
-        if (canonical && canonical !== type && registry[canonical]) regUrl = registry[canonical]
-      } catch (err) {
-        console.warn('[losos] type resolver failed:', type, err)
-      }
-    }
-  }
-  if (regUrl) {
+  if (type && registry[type]) {
+    var regUrl = registry[type]
     try {
       var mod = _paneCache.get(regUrl)
       if (!mod) {
@@ -313,19 +297,6 @@ export async function boot(el, opts) {
 
 /** Access/extend the registry */
 export { _registry as registry }
-
-/** Wire in an optional type resolver — async fn(type) returning a canonical
- *  form to retry registry lookup with. Call once at app startup, before boot.
- *  Pass null to clear.
- *
- *  Example (urn:solid resolution):
- *    import { setTypeResolver } from './losos/shell.js'
- *    import { resolveType } from './losos/urn-solid-resolver.js'
- *    setTypeResolver(resolveType)
- */
-export function setTypeResolver(fn) {
-  _typeResolver = fn
-}
 
 // Auto-boot if a known container exists
 if (document.getElementById('solid') || document.getElementById('losos') || document.getElementById('mashlib') || document.getElementById('app')) {

--- a/losos/shell.js
+++ b/losos/shell.js
@@ -5,11 +5,13 @@
 
 import { createStore } from '../lion/index.js'
 import defaultRegistry from './registry.js'
+import { loadIndex as loadUrnSolidIndex, resolve as resolveUrnSolid } from './urn-solid-resolver.js'
 
 // Module-level state — available to resolvePane after boot
 var _panes = []
 var _registry = Object.assign({}, defaultRegistry)
 var _paneCache = new Map()  // url → pane module
+var _urnSolidIndex = null   // populated lazily on first registry lookup
 
 /** Load all registered panes from data-pane script tags */
 async function loadPanes() {
@@ -250,9 +252,21 @@ export async function resolvePane(node, store, container, rawData, opts) {
   }
 
   // 3. Registry — @type → pane URL
+  // Try direct match first (preserves existing registrations like 'wf:Tracker'),
+  // then fall back to the urn:solid canonical form so a pane registered against
+  // 'urn:solid:Person' also matches incoming 'foaf:Person', 'schema:Person', etc.
   var type = node['@type']
-  if (type && registry[type]) {
-    var regUrl = registry[type]
+  var regUrl = null
+  if (type) {
+    if (registry[type]) {
+      regUrl = registry[type]
+    } else {
+      if (!_urnSolidIndex) _urnSolidIndex = await loadUrnSolidIndex()
+      var canonical = resolveUrnSolid(type, _urnSolidIndex)
+      if (canonical !== type && registry[canonical]) regUrl = registry[canonical]
+    }
+  }
+  if (regUrl) {
     try {
       var mod = _paneCache.get(regUrl)
       if (!mod) {

--- a/losos/urn-solid-resolver.js
+++ b/losos/urn-solid-resolver.js
@@ -71,6 +71,20 @@ export function normalize(obj, index) {
   return out
 }
 
+/**
+ * Convenience: async (type) → canonical urn:solid form.
+ * Loads the index lazily on first call. Pass directly to
+ * the LOSOS shell's setTypeResolver():
+ *
+ *   import { setTypeResolver } from './losos/shell.js'
+ *   import { resolveType } from './losos/urn-solid-resolver.js'
+ *   setTypeResolver(resolveType)
+ */
+export async function resolveType(type) {
+  const idx = await loadIndex()
+  return resolve(type, idx)
+}
+
 /** Reset the cached index (useful in tests). */
 export function _reset() {
   _index = null

--- a/losos/urn-solid-resolver.js
+++ b/losos/urn-solid-resolver.js
@@ -5,9 +5,21 @@
  * 'urn:solid:Person') match incoming data whose @type is the equivalent
  * upstream IRI (foaf:Person, schema:Person, etc.). The registry at
  * urn-solid.github.io publishes the reverse-lookup table; this module
- * fetches it once and uses it to normalise types/predicates at read time.
+ * fetches it once and adds aliases to your existing pane registry — so
+ * registry lookup stays a plain object access with no shell changes.
  *
- * Optional. Apps that don't import this module behave exactly as before.
+ * Standalone module. Pure opt-in. Not imported by the LOSOS shell.
+ *
+ * Recommended usage (~3 lines in your app):
+ *
+ *   import { registry } from './losos/shell.js'
+ *   import { expandRegistry } from './losos/urn-solid-resolver.js'
+ *   await expandRegistry(registry)
+ *
+ * After that, a pane registered against 'urn:solid:Person' will also match
+ * incoming 'http://xmlns.com/foaf/0.1/Person', 'https://schema.org/Person',
+ * etc. — because the registry now has those upstream IRIs as aliases for
+ * the same pane URL.
  *
  * Spec: https://urn-solid.github.io/spec/
  * Reverse index: https://urn-solid.github.io/reverse-index.json
@@ -72,17 +84,27 @@ export function normalize(obj, index) {
 }
 
 /**
- * Convenience: async (type) → canonical urn:solid form.
- * Loads the index lazily on first call. Pass directly to
- * the LOSOS shell's setTypeResolver():
+ * Add upstream-IRI aliases to a pane registry, in place.
  *
- *   import { setTypeResolver } from './losos/shell.js'
- *   import { resolveType } from './losos/urn-solid-resolver.js'
- *   setTypeResolver(resolveType)
+ * For every entry `registry[urn:solid:X] = paneUrl` you have, after this
+ * call the registry will also contain the matching upstream IRI keys
+ * (e.g. `registry['http://xmlns.com/foaf/0.1/Person'] = paneUrl`). Means
+ * the shell's existing direct-lookup path matches cross-vocab data with
+ * no shell changes.
+ *
+ *   import { registry } from './losos/shell.js'
+ *   import { expandRegistry } from './losos/urn-solid-resolver.js'
+ *   registry['urn:solid:Person'] = './panes/person-pane.js'
+ *   await expandRegistry(registry)
+ *
+ * Idempotent. Safe to call multiple times.
  */
-export async function resolveType(type) {
+export async function expandRegistry(registry) {
   const idx = await loadIndex()
-  return resolve(type, idx)
+  for (const [iri, urn] of Object.entries(idx)) {
+    if (registry[urn] && !registry[iri]) registry[iri] = registry[urn]
+  }
+  return registry
 }
 
 /** Reset the cached index (useful in tests). */

--- a/losos/urn-solid-resolver.js
+++ b/losos/urn-solid-resolver.js
@@ -1,0 +1,78 @@
+/**
+ * urn:solid resolver — canonicalise upstream RDF IRIs to their urn:solid form
+ *
+ * Lets a LOSOS pane registered against a single urn:solid type (e.g.
+ * 'urn:solid:Person') match incoming data whose @type is the equivalent
+ * upstream IRI (foaf:Person, schema:Person, etc.). The registry at
+ * urn-solid.github.io publishes the reverse-lookup table; this module
+ * fetches it once and uses it to normalise types/predicates at read time.
+ *
+ * Optional. Apps that don't import this module behave exactly as before.
+ *
+ * Spec: https://urn-solid.github.io/spec/
+ * Reverse index: https://urn-solid.github.io/reverse-index.json
+ */
+
+const REGISTRY_URL = 'https://urn-solid.github.io/reverse-index.json'
+
+let _index = null
+let _loading = null
+
+/** Fetch and cache the upstream-IRI → urn:solid lookup table. */
+export async function loadIndex(url) {
+  if (_index) return _index
+  if (_loading) return _loading
+  _loading = fetch(url || REGISTRY_URL)
+    .then(r => r.ok ? r.json() : {})
+    .then(idx => { _index = idx; _loading = null; return idx })
+    .catch(err => {
+      console.warn('[urn-solid] failed to load reverse index:', err)
+      _index = {}
+      _loading = null
+      return _index
+    })
+  return _loading
+}
+
+const isUrnSolid = s => typeof s === 'string' && s.startsWith('urn:solid:')
+const isAbsolute = s => typeof s === 'string' && /^[a-z][a-z0-9+.-]*:/i.test(s)
+
+/**
+ * Map an IRI (or bare name) to its urn:solid form when possible.
+ * - urn:solid:* → unchanged
+ * - absolute IRI in the index → urn:solid:* equivalent
+ * - absolute IRI not in the index → unchanged
+ * - bare name → urn:solid:<name> (per LION SHOULD default)
+ */
+export function resolve(iri, index) {
+  if (!iri) return iri
+  if (isUrnSolid(iri)) return iri
+  if (isAbsolute(iri)) return (index && index[iri]) || iri
+  return 'urn:solid:' + iri
+}
+
+/**
+ * Normalise an entire JSON-LD-shaped object: @type values and predicate
+ * keys are mapped to urn:solid form. Returns a new object; input untouched.
+ */
+export function normalize(obj, index) {
+  if (Array.isArray(obj)) return obj.map(o => normalize(o, index))
+  if (obj === null || typeof obj !== 'object') return obj
+  const out = {}
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === '@type') {
+      out[k] = Array.isArray(v) ? v.map(t => resolve(t, index)) : resolve(v, index)
+    } else if (k.startsWith('@')) {
+      out[k] = v
+    } else {
+      out[resolve(k, index)] = normalize(v, index)
+    }
+  }
+  return out
+}
+
+/** Reset the cached index (useful in tests). */
+export function _reset() {
+  _index = null
+  _loading = null
+}


### PR DESCRIPTION
Implements the design from #8.

## What this does

Lets a pane registered against \`urn:solid:Person\` match incoming data whose \`@type\` is the equivalent upstream IRI (\`foaf:Person\`, \`schema:Person\`, etc.) or a bare \`Person\`. The canonicalisation happens at read time via the published [urn-solid reverse index](https://urn-solid.github.io/reverse-index.json) — **no app migration required.**

## What's in the diff

**\`losos/urn-solid-resolver.js\`** (new, ~80 lines):
- \`loadIndex()\` — fetches the reverse-lookup table once, caches, graceful fallback if network fails
- \`resolve(iri, index)\` — maps an IRI or bare name to its urn:solid form
- \`normalize(obj, index)\` — canonicalises every \`@type\` and predicate key in a JSON-LD-shaped object

**\`shell.js\`** (wiring, ~10 line change):
- Direct registry lookup runs first — preserves zero-cost backward compat for existing entries (\`wf:Tracker\`, \`ical:Vtodo\`)
- If direct lookup misses, the urn:solid canonical form is tried
- Index loaded lazily on first miss — apps that never hit it pay nothing

## Backward compatibility

- Every existing registration and app behaves exactly as before.
- The resolver only kicks in when the direct lookup *misses* — so it can only *add* matches, never change existing ones.
- Apps that don't import it are unaffected (the import lives in \`shell.js\`, but the runtime cost is just one network fetch per session, lazy).

## Smoke test

\`\`\`
resolve('http://xmlns.com/foaf/0.1/Person', index) → 'urn:solid:Person'
resolve('Person', index)                            → 'urn:solid:Person'
resolve('urn:solid:Person', index)                  → 'urn:solid:Person'
resolve('schema:Person', index)                     → 'schema:Person' (passthrough — see caveat)
\`\`\`

## Honest caveats

1. **Compact-form IRIs aren't expanded.** The resolver looks up *full* IRIs in the index. If a document uses prefix:term form (\`\"foaf:name\"\`) without a JSON-LD context expansion pass, it stays unchanged. For LOSOS docs that already get parsed through LION/JSON-LD this is fine; for raw inputs it's a follow-up.
2. **One-way (read-side).** Doesn't help on write — if a LOSOS app needs to emit data in the original vocabulary, it has to remember the input form.
3. **Cache freshness.** First load fetches the index; subsequent calls use the cache. For long-running tabs add a TTL or version-pin (follow-up).

## Test plan

- [ ] Existing apps continue to render with no behavioural change (registry hits first, no fallback triggered).
- [ ] Add a pane registered against \`urn:solid:Person\` and verify it renders \`@type: \"http://xmlns.com/foaf/0.1/Person\"\` data.
- [ ] Verify the lazy index fetch happens at most once per session.
- [ ] Verify graceful behaviour when offline / network failure (resolver returns input unchanged).

Refs: #8, #6, #7