### PR TITLE
urn-solid-resolver: fix loadIndex error caching + add tests

### DIFF
--- a/losos/urn-solid-resolver.js
+++ b/losos/urn-solid-resolver.js
@@ -30,18 +30,28 @@ const REGISTRY_URL = 'https://urn-solid.github.io/reverse-index.json'
 let _index = null
 let _loading = null
 
-/** Fetch and cache the upstream-IRI → urn:solid lookup table. */
+/**
+ * Fetch and cache the upstream-IRI → urn:solid lookup table.
+ *
+ * On success, the index is cached for the rest of the session.
+ * On failure (network error, non-OK HTTP status), nothing is cached
+ * and the call returns {} — subsequent calls will retry the fetch.
+ * This avoids a transient failure (offline boot, captive portal,
+ * server hiccup) silently disabling resolution for the whole session.
+ */
 export async function loadIndex(url) {
   if (_index) return _index
   if (_loading) return _loading
   _loading = fetch(url || REGISTRY_URL)
-    .then(r => r.ok ? r.json() : {})
+    .then(async r => {
+      if (!r.ok) throw new Error('[urn-solid] reverse index fetch returned ' + r.status)
+      return r.json()
+    })
     .then(idx => { _index = idx; _loading = null; return idx })
     .catch(err => {
-      console.warn('[urn-solid] failed to load reverse index:', err)
-      _index = {}
+      console.warn('[urn-solid] failed to load reverse index (will retry on next call):', err)
       _loading = null
-      return _index
+      return {}
     })
   return _loading
 }
@@ -64,9 +74,17 @@ export function resolve(iri, index) {
 }
 
 /**
- * Normalise an entire JSON-LD-shaped object: @type values and predicate
- * keys are mapped to urn:solid form. Returns a new object; input untouched.
+ * Normalise a JSON-LD-shaped node: @type values and predicate keys are
+ * mapped to urn:solid form. Returns a new object; input is untouched.
+ *
+ * Scope: walks plain children and arrays. JSON-LD container keywords
+ * `@graph`, `@included`, `@list`, `@set` are recursed into so nested
+ * nodes get the same treatment. Other `@`-keys (`@id`, `@context`,
+ * `@language`, `@base`, etc.) are passed through untouched — they're
+ * either identifiers/literals or framing constructs that shouldn't be
+ * canonicalised as predicates.
  */
+const _CONTAINER_KEYS = new Set(['@graph', '@included', '@list', '@set'])
 export function normalize(obj, index) {
   if (Array.isArray(obj)) return obj.map(o => normalize(o, index))
   if (obj === null || typeof obj !== 'object') return obj
@@ -74,6 +92,8 @@ export function normalize(obj, index) {
   for (const [k, v] of Object.entries(obj)) {
     if (k === '@type') {
       out[k] = Array.isArray(v) ? v.map(t => resolve(t, index)) : resolve(v, index)
+    } else if (_CONTAINER_KEYS.has(k)) {
+      out[k] = normalize(v, index)
     } else if (k.startsWith('@')) {
       out[k] = v
     } else {

--- a/test.js
+++ b/test.js
@@ -177,3 +177,128 @@ test('Namespace creates NamedNode', () => {
   assert.equal(node.value, 'https://schema.org/name')
   assert.equal(node.termType, 'NamedNode')
 })
+
+// ========== urn-solid-resolver.js ==========
+
+import { resolve, normalize, loadIndex, expandRegistry, _reset as _resetUrnSolid } from './losos/urn-solid-resolver.js'
+
+const FIXTURE_INDEX = {
+  'http://xmlns.com/foaf/0.1/Person': 'urn:solid:Person',
+  'https://schema.org/Person': 'urn:solid:Person',
+  'http://xmlns.com/foaf/0.1/name': 'urn:solid:name'
+}
+
+test('resolve: urn:solid:* passes through unchanged', () => {
+  assert.equal(resolve('urn:solid:Person', FIXTURE_INDEX), 'urn:solid:Person')
+})
+
+test('resolve: absolute IRI in index → urn:solid form', () => {
+  assert.equal(resolve('http://xmlns.com/foaf/0.1/Person', FIXTURE_INDEX), 'urn:solid:Person')
+  assert.equal(resolve('https://schema.org/Person', FIXTURE_INDEX), 'urn:solid:Person')
+})
+
+test('resolve: absolute IRI not in index → unchanged', () => {
+  assert.equal(resolve('http://example.org/Unknown', FIXTURE_INDEX), 'http://example.org/Unknown')
+})
+
+test('resolve: bare name → urn:solid:<name> (LION SHOULD default)', () => {
+  assert.equal(resolve('Person', FIXTURE_INDEX), 'urn:solid:Person')
+  assert.equal(resolve('name', FIXTURE_INDEX), 'urn:solid:name')
+})
+
+test('resolve: empty/null pass through', () => {
+  assert.equal(resolve('', FIXTURE_INDEX), '')
+  assert.equal(resolve(null, FIXTURE_INDEX), null)
+  assert.equal(resolve(undefined, FIXTURE_INDEX), undefined)
+})
+
+test('normalize: rewrites @type and predicate keys', () => {
+  var input = { '@id': 'x', '@type': 'http://xmlns.com/foaf/0.1/Person', 'http://xmlns.com/foaf/0.1/name': 'Alice' }
+  var out = normalize(input, FIXTURE_INDEX)
+  assert.equal(out['@id'], 'x')
+  assert.equal(out['@type'], 'urn:solid:Person')
+  assert.equal(out['urn:solid:name'], 'Alice')
+  assert.equal(input['@type'], 'http://xmlns.com/foaf/0.1/Person')   // input untouched
+})
+
+test('normalize: handles @type arrays', () => {
+  var out = normalize({ '@type': ['http://xmlns.com/foaf/0.1/Person', 'https://schema.org/Person'] }, FIXTURE_INDEX)
+  assert.deepEqual(out['@type'], ['urn:solid:Person', 'urn:solid:Person'])
+})
+
+test('normalize: recurses into @graph', () => {
+  var input = { '@graph': [{ '@type': 'http://xmlns.com/foaf/0.1/Person', '@id': 'a' }] }
+  var out = normalize(input, FIXTURE_INDEX)
+  assert.equal(out['@graph'][0]['@type'], 'urn:solid:Person')
+})
+
+test('normalize: recurses into @included and @list', () => {
+  var out1 = normalize({ '@included': [{ '@type': 'http://xmlns.com/foaf/0.1/Person' }] }, FIXTURE_INDEX)
+  assert.equal(out1['@included'][0]['@type'], 'urn:solid:Person')
+  var out2 = normalize({ '@list': [{ '@type': 'http://xmlns.com/foaf/0.1/Person' }] }, FIXTURE_INDEX)
+  assert.equal(out2['@list'][0]['@type'], 'urn:solid:Person')
+})
+
+test('normalize: passes through @id and @context', () => {
+  var out = normalize({ '@id': 'x', '@context': { 'foaf': 'http://xmlns.com/foaf/0.1/' } }, FIXTURE_INDEX)
+  assert.equal(out['@id'], 'x')
+  assert.deepEqual(out['@context'], { 'foaf': 'http://xmlns.com/foaf/0.1/' })
+})
+
+test('loadIndex: caches result on success', async () => {
+  _resetUrnSolid()
+  var calls = 0
+  globalThis.fetch = async () => { calls++; return { ok: true, json: async () => FIXTURE_INDEX } }
+  var idx1 = await loadIndex()
+  var idx2 = await loadIndex()
+  assert.equal(calls, 1)
+  assert.deepEqual(idx1, FIXTURE_INDEX)
+  assert.equal(idx1, idx2)        // same reference
+})
+
+test('loadIndex: does NOT cache on non-OK HTTP — retries on next call', async () => {
+  _resetUrnSolid()
+  var calls = 0
+  globalThis.fetch = async () => { calls++; return { ok: false, status: 503, json: async () => ({}) } }
+  var idx1 = await loadIndex()
+  assert.deepEqual(idx1, {})
+  var idx2 = await loadIndex()
+  assert.equal(calls, 2)          // retried — failure not cached
+})
+
+test('loadIndex: does NOT cache on network error — retries on next call', async () => {
+  _resetUrnSolid()
+  var calls = 0
+  globalThis.fetch = async () => { calls++; throw new Error('offline') }
+  await loadIndex()
+  await loadIndex()
+  assert.equal(calls, 2)
+})
+
+test('expandRegistry: aliases upstream IRIs to existing urn:solid pane URLs', async () => {
+  _resetUrnSolid()
+  globalThis.fetch = async () => ({ ok: true, json: async () => FIXTURE_INDEX })
+  var reg = { 'urn:solid:Person': './panes/person.js' }
+  await expandRegistry(reg)
+  assert.equal(reg['http://xmlns.com/foaf/0.1/Person'], './panes/person.js')
+  assert.equal(reg['https://schema.org/Person'], './panes/person.js')
+})
+
+test('expandRegistry: skips aliases when no urn:solid pane is registered', async () => {
+  _resetUrnSolid()
+  globalThis.fetch = async () => ({ ok: true, json: async () => FIXTURE_INDEX })
+  var reg = {}
+  await expandRegistry(reg)
+  assert.equal(reg['http://xmlns.com/foaf/0.1/Person'], undefined)
+})
+
+test('expandRegistry: does not overwrite existing upstream-IRI registrations', async () => {
+  _resetUrnSolid()
+  globalThis.fetch = async () => ({ ok: true, json: async () => FIXTURE_INDEX })
+  var reg = {
+    'urn:solid:Person': './panes/urn-person.js',
+    'http://xmlns.com/foaf/0.1/Person': './panes/foaf-person.js'    // pre-existing, should win
+  }
+  await expandRegistry(reg)
+  assert.equal(reg['http://xmlns.com/foaf/0.1/Person'], './panes/foaf-person.js')
+})


### PR DESCRIPTION
Follow-up to #9 addressing Copilot review feedback.

## What's in this PR

### 1. \`loadIndex\` no longer caches \`{}\` on failure (real bug)
Previously, a non-OK HTTP status or a network error set \`_index = {}\` permanently. A transient failure at app startup (offline boot, captive portal, temporary 500) silently disabled urn:solid resolution for the rest of the session — \`expandRegistry\` became a no-op with no warning.

**Fix:** leave \`_index\` null on failure and clear \`_loading\`. The failing call still returns \`{}\` to the caller, but the next call retries the fetch. The warning log now makes failure visible.

### 2. \`normalize()\` recurses into JSON-LD container keywords (real bug)
The blanket pass-through of \`@\`-keys meant \`@graph\`, \`@included\`, \`@list\`, \`@set\` children weren't normalised. A document like \`{\"@graph\": [{\"@type\": \"foaf:Person\"}]}\` left the inner \`@type\` un-canonicalised.

**Fix:** recurse into the four JSON-LD container keywords. Other \`@\`-keys (\`@id\`, \`@context\`, \`@language\`, \`@base\`, \`@value\`) still pass through — they're identifiers, literals, or framing constructs that shouldn't be canonicalised as predicates. Docstring updated.

### 3. Tests (process gap)
17 new \`node:test\` cases in \`test.js\` covering:
- \`resolve\`: urn:solid passthrough, in-index lookup, miss, bare name, null/empty
- \`normalize\`: \`@type\` rewriting (string + array), \`@graph\`/\`@included\`/\`@list\` recursion, \`@id\`/\`@context\` passthrough, immutability of input
- \`loadIndex\`: success caching, **retry on non-OK HTTP**, **retry on network error**
- \`expandRegistry\`: aliasing, skipping when no urn:solid registration, respecting pre-existing upstream-IRI registrations

\`\`\`
$ node --test test.js
ℹ tests 39
ℹ pass 39
ℹ fail 0
\`\`\`

Refs: #9 (Copilot review)