### PR TITLE
shell: tab color defaults that work on light AND dark backgrounds

### DIFF
--- a/losos/shell.js
+++ b/losos/shell.js
@@ -120,12 +120,12 @@ function findSubject(store, baseUrl) {
 /** Render pane tabs with built-in persistence */
 function renderTabs(panes, container, subject, store, rawData, opts) {
   var maxWidth = opts.maxWidth || '960px'
-  var tabColor = opts.tabColor || 'rgba(255,255,255,0.5)'
-  var tabActiveColor = opts.tabActiveColor || 'rgba(255,255,255,0.9)'
+  var tabColor = opts.tabColor || 'rgba(127,127,127,0.55)'
+  var tabActiveColor = opts.tabActiveColor || (opts.accentColor || '#7c3aed')
 
   const tabBar = document.createElement('div')
   tabBar.id = 'pane-tabs'
-  tabBar.style.cssText = 'display:flex;gap:0;border-bottom:1px solid rgba(255,255,255,0.08);overflow-x:auto;max-width:' + maxWidth + ';margin:0 auto'
+  tabBar.style.cssText = 'display:flex;gap:0;border-bottom:1px solid rgba(127,127,127,0.18);overflow-x:auto;max-width:' + maxWidth + ';margin:0 auto'
 
   const content = document.createElement('div')
   content.id = 'pane-container'


### PR DESCRIPTION
Implements #13.

## What changes

Three color defaults in \`renderTabs()\`:

| | before | after |
|---|---|---|
| \`tabColor\` | \`rgba(255,255,255,0.5)\` | \`rgba(127,127,127,0.55)\` |
| \`tabActiveColor\` | \`rgba(255,255,255,0.9)\` | \`opts.accentColor \|\| '#7c3aed'\` |
| tabBar border-bottom | \`rgba(255,255,255,0.08)\` | \`rgba(127,127,127,0.18)\` |

Three-line diff total. No new mechanism, no new opts, no new branches.

## Why

Default \`rgba(255,255,255,0.5)\` is white-on-white on every light-bg app — including \`examples/dashboard/\` and the \`losos.org/examples/vcard\` demo (which already works around it via \`!important\` CSS). Medium-gray-with-transparency is readable on either polarity.

Active tab now defaults to the existing accent color (already used for the bottom-border underline). One color, two visual cues, consistent. \`opts.tabActiveColor\` still overrides if set.

Apps that pass explicit \`opts.tabColor\` / \`tabActiveColor\` continue to override exactly as before. Apps overriding via CSS \`!important\` (vcard) continue to win regardless. **Zero behaviour change for any app that already worked around the issue.**

## Size

Tested locally:

| | raw | gzip |
|---|---|---|
| Before | 10,462 | 3,340 |
| After | 10,471 | **3,336** |
| Delta | +9 | **−4** |

Effectively zero. New colors compress slightly better.

## Tested

Local server (python3 http.server) against \`examples/dashboard/\` (white background) and \`drop-demo.html\` — both render readable tabs with the purple accent on the active tab. Screenshot in #13.

## Test plan

- [ ] Open \`examples/dashboard/\` — Dashboard and Source tabs both clearly readable; Dashboard active in purple.
- [ ] Open \`drop-demo.html\` — same pattern.
- [ ] Open one of the existing dark-themed contexts if any — confirm gray-on-dark is still readable (medium gray with 0.55 opacity stays legible against dark bg).
- [ ] Confirm no regression in apps passing explicit color opts (e.g. anything using \`opts.tabColor\`).