### PR TITLE
losos/html: skip patch shortcut when cached DOM was wiped (#15)

### DIFF
--- a/losos/html.js
+++ b/losos/html.js
@@ -43,8 +43,8 @@ export function render(container, template) {
 
   var prev = cache.get(container)
 
-  // Same template shape — patch only the holes
-  if (prev && prev.strings === template.strings) {
+  // Same template — patch holes. Skip if cached DOM was wiped (#15).
+  if (prev && prev.strings === template.strings && container.firstChild) {
     patch(prev.parts, prev.values, template.values)
     prev.values = template.values
     return


### PR DESCRIPTION
Closes #15.

## Summary
- Tagged-template `strings` arrays are interned, so `prev.strings === template.strings` matches the cache forever — even when the container was wiped externally between renders. `patch()` then mutates orphan nodes in `prev.parts` and silently no-ops.
- Add a `container.firstChild` guard before taking the patch shortcut. Falls through to the existing fresh-build path on cache miss / stale cache.

2 lines changed (one comment, one extra condition on the existing `if`). +90 bytes.

## Why `container.firstChild` and not `container.contains(prev.parts[0].node)`
The earlier draft of this PR used `prev.parts[0]?.node` for the validity check. As Copilot pointed out, that breaks the patch fast-path for **static templates** with zero `${}` holes — `parts` is empty, the check fails, every rerender does a full rebuild and resets element state (input focus, selection, etc).

`container.firstChild` works for both shapes: it's truthy when the container has any rendered DOM at all, falsy after `innerHTML = ''`. No regression on static templates.

## Why only `losos/html.js` and not the root `html.js`
`package.json` exports `./html` → `./losos/html.js`, and `files` only includes `losos/`. The duplicate `html.js` at the repo root isn't published and isn't what consumers import. Fixing it doesn't reach anyone. Filed separately as #17 — eliminating that duplicate is a different problem.

## Test plan
- [x] `node -c losos/html.js` syntax passes.
- [x] Manual: served via the LOSOS shell at `nosdav/browser`'s clone — switching tabs no longer blanks source-pane (the originating real-world hit).
- [ ] Repro from #15 (`render`, clear `innerHTML`, `render` again with same template) returns the expected DOM after the fix.
- [ ] Static template (`html\`<p>static</p>\``) rerendered twice still hits the patch fast-path (parts is empty but `container.firstChild` is truthy → no full rebuild).